### PR TITLE
Determine executed specs automatically from RSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,9 @@ Add something like the following to your `spec/spec_helper.rb` file:
 
 ```rb
 require 'simplecov'
-if (executed_spec_files = ARGV.grep(%r{\Aspec/.+_spec\.rb})).size == 1
+if ARGV.grep(%r{\Aspec/.+_spec\.rb}).size == 1
   require 'simple_cov/formatter/terminal'
   SimpleCov.formatter = SimpleCov::Formatter::Terminal
-  SimpleCov::Formatter::Terminal.executed_spec_file = executed_spec_files.first
 end
 SimpleCov.start do
   add_filter(%r{^/spec/})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,9 @@ require 'simplecov'
 if ENV.fetch('CI', nil) == 'true'
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
-elsif (executed_spec_files = ARGV.grep(%r{\Aspec/.+_spec\.rb})).size == 1
+elsif ARGV.grep(%r{\Aspec/.+_spec\.rb}).size == 1
   require 'simple_cov/formatter/terminal'
   SimpleCov.formatter = SimpleCov::Formatter::Terminal
-  SimpleCov::Formatter::Terminal.executed_spec_file = executed_spec_files.first
 end
 SimpleCov.start do
   add_filter(%r{\A/spec/})


### PR DESCRIPTION
This is nice because it really simplifies the code that must be pasted into `spec_helper.rb` to use this gem.