### PR TITLE
Illustrate `SimpleCov.start` without a block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ if ARGV.grep(%r{\Aspec/.+_spec\.rb}).size == 1
   require 'simple_cov/formatter/terminal'
   SimpleCov.formatter = SimpleCov::Formatter::Terminal
 end
-SimpleCov.start do
-  add_filter(%r{^/spec/})
-end
+SimpleCov.start
 ```
 
 Note that `SimpleCov::Formatter::Terminal` will only be used when specs are run with a single spec


### PR DESCRIPTION
This is simpler (and still valid) and doesn't distract from the code above that pertains to this gem. I don't think it will cause much confusion for users who are using `SimpleCov.start` with a block.