### PR TITLE
Support ignoring missing branch coverage

### DIFF
--- a/lib/simple_cov/formatter/terminal.rb
+++ b/lib/simple_cov/formatter/terminal.rb
@@ -50,7 +50,7 @@ class SimpleCov::Formatter::Terminal
     )
 
     def setup_rspec
-      return if @rspec_is_set_up
+      return if @rspec_is_set_up # :nocov-else:
 
       # We can't easily test this, since we use this library in its own RSpec tests,
       # so we'd be setting it up twice if we tested it, which would be a bit of a problem.
@@ -128,7 +128,12 @@ class SimpleCov::Formatter::Terminal
 
   memoize \
   def uncovered_branches(sourcefile)
-    sourcefile.branches.reject(&:covered?)
+    sourcefile.branches.
+      reject(&:covered?).
+      reject do |branch|
+        source_code = sourcefile.lines[branch.start_line - 1].src
+        source_code.match?(/# :nocov-(else|when):/)
+      end
   end
 
   def print_coverage_details(sourcefile)

--- a/spec/simple_cov/formatter/terminal_spec.rb
+++ b/spec/simple_cov/formatter/terminal_spec.rb
@@ -200,13 +200,14 @@ RSpec.describe SimpleCov::Formatter::Terminal do
         SimpleCov::SourceFile::Line,
         line_number: 1,
         skipped?: false,
-        source: "# frozen_string_literal\n",
+        src: "# frozen_string_literal\n",
         coverage:,
       )
     end
     let(:sourcefile) do
       instance_double(
         SimpleCov::SourceFile,
+        lines: [line],
         branches:,
       )
     end
@@ -417,13 +418,14 @@ RSpec.describe SimpleCov::Formatter::Terminal do
         SimpleCov::SourceFile::Line,
         line_number: 1,
         skipped?: false,
-        source: "puts(rand(10) < 5 ? 'hello world' : 'goodbye world')\n",
+        src: "puts(rand(10) < 5 ? 'hello world' : 'goodbye world')\n",
         coverage: 1,
       )
     end
     let(:sourcefile) do
       instance_double(
         SimpleCov::SourceFile,
+        lines: [line],
         branches: [
           instance_double(
             SimpleCov::SourceFile::Branch,


### PR DESCRIPTION
Add a `# :nocov-else:` or a `# :nocov-when:` comment.