### PR TITLE
Wrap README screenshot in <piture> tag so GitHub doesn't autolink it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SimpleCov::Formatter::Terminal
 
-![image](https://user-images.githubusercontent.com/8197963/195740768-e2cbb99d-7cf2-42bf-a178-2f78eb653dd3.png)
+<picture>
+  <img alt="Screenshot of SimpleCov::Formatter::Terminal" src="https://user-images.githubusercontent.com/8197963/195740768-e2cbb99d-7cf2-42bf-a178-2f78eb653dd3.png">
+</picture>
 
 ## Installation
 


### PR DESCRIPTION
The way it was before, GitHub makes the image an <a> tag that opens the image in a new tab.