### PR TITLE
Revert "Wrap README screenshot in <piture> tag so GitHub doesn't autolink it"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # SimpleCov::Formatter::Terminal
 
-<picture>
-  <img alt="Screenshot of SimpleCov::Formatter::Terminal" src="https://user-images.githubusercontent.com/8197963/195740768-e2cbb99d-7cf2-42bf-a178-2f78eb653dd3.png">
-</picture>
+![image](https://user-images.githubusercontent.com/8197963/195740768-e2cbb99d-7cf2-42bf-a178-2f78eb653dd3.png)
 
 ## Installation
 


### PR DESCRIPTION
Reverts davidrunger/simple_cov-formatter-terminal#32

The image has `visibility: hidden' and doesn't show up.