### PR TITLE
Write target file to `tmp/` directory (not root `.simplecov_target`)

### DIFF
--- a/lib/simple_cov/formatter/terminal.rb
+++ b/lib/simple_cov/formatter/terminal.rb
@@ -108,7 +108,9 @@ class SimpleCov::Formatter::Terminal
   end
 
   def write_target_info_file
-    File.write('./.simplecov_target', "#{targeted_application_file}\n")
+    directory = 'tmp/simple_cov/formatter/terminal'
+    FileUtils.mkdir_p(directory)
+    File.write("#{directory}/target.txt", "#{targeted_application_file}\n")
   end
 
   def print_coverage_info(result)

--- a/spec/simple_cov/formatter/terminal_spec.rb
+++ b/spec/simple_cov/formatter/terminal_spec.rb
@@ -580,10 +580,10 @@ RSpec.describe SimpleCov::Formatter::Terminal do
 
       let(:targeted_application_file) { 'lib/simple_cov/formatter/terminal.rb' }
 
-      it 'writes the targeted file name to .simplecov_target' do
+      it 'writes the targeted file name to tmp/simple_cov/formatter/terminal/target.txt' do
         expect(File).
           to receive(:write).
-          with('./.simplecov_target', "#{targeted_application_file}\n")
+          with('tmp/simple_cov/formatter/terminal/target.txt', "#{targeted_application_file}\n")
 
         write_target_info_file
       end


### PR DESCRIPTION
I think that writing a file to the root directory might be problematic when using `spring` and/or `guard` because it triggers their listeners.