### PR TITLE
Add RSpec as a gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
       activesupport (>= 7.0.4, < 8)
       memoist (>= 0.16.2, < 1)
       rouge (>= 4.0.0, < 5)
+      rspec (>= 3.11.0, < 4)
       simplecov (>= 0.21.2, < 1)
 
 GEM

--- a/simple_cov-formatter-terminal.gemspec
+++ b/simple_cov-formatter-terminal.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('activesupport', '>= 7.0.4', '< 8')
   spec.add_dependency('memoist', '>= 0.16.2', '< 1')
   spec.add_dependency('rouge', '>= 4.0.0', '< 5')
+  spec.add_dependency('rspec', '>= 3.11.0', '< 4')
   spec.add_dependency('simplecov', '>= 0.21.2', '< 1')
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
We do reference RSpec in the library code, so it is a runtime gem dependency (not just required for the gem's own testing).