### PR TITLE
Require `rspec/core` in `terminal.rb`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       activesupport (>= 7.0.4, < 8)
       memoist (>= 0.16.2, < 1)
       rouge (>= 4.0.0, < 5)
-      rspec (>= 3.11.0, < 4)
+      rspec-core (>= 3.11.0, < 4)
       simplecov (>= 0.21.2, < 1)
 
 GEM

--- a/lib/simple_cov/formatter/terminal.rb
+++ b/lib/simple_cov/formatter/terminal.rb
@@ -4,6 +4,7 @@ require_relative 'terminal/version'
 require 'active_support/core_ext/string/filters'
 require 'memoist'
 require 'rouge'
+require 'rspec/core'
 
 class SimpleCov::Formatter::Terminal
   extend Memoist

--- a/simple_cov-formatter-terminal.gemspec
+++ b/simple_cov-formatter-terminal.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('activesupport', '>= 7.0.4', '< 8')
   spec.add_dependency('memoist', '>= 0.16.2', '< 1')
   spec.add_dependency('rouge', '>= 4.0.0', '< 5')
-  spec.add_dependency('rspec', '>= 3.11.0', '< 4')
+  spec.add_dependency('rspec-core', '>= 3.11.0', '< 4')
   spec.add_dependency('simplecov', '>= 0.21.2', '< 1')
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
Also, make only rspec-core a gem dependency.