### PR TITLE
Move `SimpleCov.start` call higher in `spec_helper.rb`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
-require 'climate_control'
 require 'simplecov'
-if ENV.fetch('CI', nil) == 'true'
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-elsif RSpec.configuration.files_to_run.one?
-  require 'simple_cov/formatter/terminal'
-  SimpleCov.formatter = SimpleCov::Formatter::Terminal
-end
 SimpleCov.start do
   add_filter(%r{\A/spec/})
   enable_coverage(:branch)
 end
-
-load 'simple_cov/formatter/terminal.rb'
+require 'simple_cov/formatter/terminal'
+if ENV.fetch('CI', nil) == 'true'
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+elsif RSpec.configuration.files_to_run.one?
+  SimpleCov.formatter = SimpleCov::Formatter::Terminal
+end
+require 'climate_control'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
The situation is pretty confusing because we're using this library to provide coverage info for its own specs, but this semes to produce a better result than before.