### PR TITLE
Define SimpleCov::Formatter::Terminal class before requires

### DIFF
--- a/lib/simple_cov/formatter/terminal.rb
+++ b/lib/simple_cov/formatter/terminal.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+class SimpleCov::Formatter::Terminal ; end # rubocop:disable Lint/EmptyClass
+
 require_relative 'terminal/config'
 require_relative 'terminal/file_determiner'
 require_relative 'terminal/result_printer'


### PR DESCRIPTION
Fixes: uninitialized constant SimpleCov::Formatter::Terminal (NameError)