### PR TITLE
Remove allowed_push_host from gemspec

### DIFF
--- a/simple_cov-formatter-terminal.gemspec
+++ b/simple_cov-formatter-terminal.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.2.0'
 
-  spec.metadata['allowed_push_host'] = 'https://davidrunger.com/'
-
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/davidrunger/simplecov-formatter-terminal'
   spec.metadata['changelog_uri'] =


### PR DESCRIPTION
This was a measure to make sure we didn't accidentally push to RubyGems. However, I now do want to actually be able to push to RubyGems.