### PR TITLE
Change references to "master" branch to "main"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
 
   pull_request:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Rename primary branch from `master` to `main`
 
 ## v1.1.0 (2024-02-02)
 - Source Ruby version from `.ruby-version` file

--- a/simple_cov-formatter-terminal.gemspec
+++ b/simple_cov-formatter-terminal.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/davidrunger/simple_cov-formatter-terminal'
   spec.metadata['changelog_uri'] =
-    'https://github.com/davidrunger/simple_cov-formatter-terminal/blob/master/CHANGELOG.md'
+    'https://github.com/davidrunger/simple_cov-formatter-terminal/blob/main/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
I have renamed the "master" branch in GitHub to "main", so we need to update these references to reflect that change.