### PR TITLE
[gemspec] Remove upper bounds on versions for all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove upper bounds on versions for all dependencies
 
 ## v1.6.0 (2024-07-30)
 - Make terminal hyperlink pattern an ENV var (`SIMPLECOV_TERMINAL_HYPERLINK_PATTERN`) rather than a Ruby setting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     simple_cov-formatter-terminal (1.6.1.alpha)
-      activesupport (>= 7.0.4, < 8)
-      memo_wise (>= 1.7.0, < 2)
-      rouge (>= 4.0.0, < 5)
-      rspec-core (>= 3.11.0, < 4)
+      activesupport (>= 7.0.4)
+      memo_wise (>= 1.7.0)
+      rouge (>= 4.0.0)
+      rspec-core (>= 3.11.0)
       runger_config (>= 3.0.0)
-      simplecov (>= 0.21.2, < 1)
+      simplecov (>= 0.21.2)
 
 GEM
   remote: https://rubygems.org/

--- a/simple_cov-formatter-terminal.gemspec
+++ b/simple_cov-formatter-terminal.gemspec
@@ -33,12 +33,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency('activesupport', '>= 7.0.4', '< 8')
-  spec.add_dependency('memo_wise', '>= 1.7.0', '< 2')
-  spec.add_dependency('rouge', '>= 4.0.0', '< 5')
-  spec.add_dependency('rspec-core', '>= 3.11.0', '< 4')
+  spec.add_dependency('activesupport', '>= 7.0.4')
+  spec.add_dependency('memo_wise', '>= 1.7.0')
+  spec.add_dependency('rouge', '>= 4.0.0')
+  spec.add_dependency('rspec-core', '>= 3.11.0')
   spec.add_dependency('runger_config', '>= 3.0.0')
-  spec.add_dependency('simplecov', '>= 0.21.2', '< 1')
+  spec.add_dependency('simplecov', '>= 0.21.2')
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Let's optimistically assume that all future versions will be compatible. We can add restrictions if that turns out not to be the case. The upside of this change is that we don't have to make changes in this gem when new versions of these dependencies are released.