### PR TITLE
Require default and test gems in spec_helper.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'climate_control', require: false
+  gem 'climate_control'
   gem 'rspec', require: false
   gem 'simplecov', require: false
   gem 'simplecov-cobertura', require: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,9 @@ if ENV.fetch('CI', nil) == 'true'
 elsif RSpec.configuration.files_to_run.one?
   SimpleCov.formatter = SimpleCov::Formatter::Terminal
 end
-require 'climate_control'
+
+require 'bundler/setup'
+Bundler.require(:default, 'test')
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This way, gems added to the `test` group (e.g. `climate_control`, as seen in this change) will automatically be available in specs.