### PR TITLE
Change test from symbol to string in Bundler.require call

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ elsif RSpec.configuration.files_to_run.one?
 end
 
 require 'bundler/setup'
-Bundler.require(:default, 'test')
+Bundler.require(:default, :test)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
No major reason. Consistency. Symbols are better.